### PR TITLE
use notifies :restart

### DIFF
--- a/recipes/pld.rb
+++ b/recipes/pld.rb
@@ -12,12 +12,12 @@
 # Set timezone for PLD family:  Put the timezone string in plain text in
 # /etc/sysconfig/timezone and then re-run the timezone service to pick it up.
 
-template "/etc/sysconfig/timezone" do
-  source "timezone.conf.erb"
+template '/etc/sysconfig/timezone' do
+  source 'timezone.conf.erb'
   owner 'root'
   group 'root'
   mode 0644
-  notifies :reload, 'service[timezone]'
+  notifies :restart, 'service[timezone]'
 end
 
 service 'timezone' do

--- a/recipes/pld.rb
+++ b/recipes/pld.rb
@@ -17,7 +17,7 @@ template '/etc/sysconfig/timezone' do
   owner 'root'
   group 'root'
   mode 0644
-  notifies :restart, 'service[timezone]'
+  notifies :restart, 'service[timezone]', :immediately
 end
 
 service 'timezone' do


### PR DESCRIPTION
somewhy `notifies :reload` does not even invoke initscript, and as reload
and restart actions are identical in pld this change is okay

i initially thought the problem is identical as #13, but was not, `:immediately` did not help
also tried to add `supports [:reload]` to service the reload methods just were not called out. tried to debug in chef, but got lost quite soon.

anyway, this is safe to add as code what gets invoked is identical
