### PR TITLE
Debian: restart cron and rsyslog on timezone change

### DIFF
--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -23,6 +23,16 @@ end
 
 execute 'dpkg-reconfigure-tzdata' do
   command '/usr/sbin/dpkg-reconfigure -f noninteractive tzdata'
+  notifies :restart, 'service[cron]', :immediately
+  notifies :restart, 'service[rsyslog]', :immediately
+  action :nothing
+end
+
+service 'cron' do
+  action :nothing
+end
+
+service 'rsyslog' do
   action :nothing
 end
 

--- a/spec/recipes/debian_spec.rb
+++ b/spec/recipes/debian_spec.rb
@@ -19,6 +19,11 @@ describe 'timezone-ii::debian' do
     it 'should do nothing by default' do
       expect(execute).to do_nothing
     end
+
+    it 'should notify daemons to restart' do
+      expect(execute).to notify('service[cron]').to(:restart).immediately
+      expect(execute).to notify('service[rsyslog]').to(:restart).immediately
+    end
   end
 
   context 'log[if-unexpected-timezone-change]' do


### PR DESCRIPTION
We're using your timezone-ii book on ubuntu and it's working great (thanks!).  However, we've noticed a few daemons that need a kick after the update in order to pickup the change.  In particular cron and rsyslog definitely need restarting and are part of any ubuntu base install (at least >= 12.04).

This PR adds those process restarts.  However, I can only confirm it's safe on a "normal" Ubuntu system.  It might fail on Ubuntu if cron or rsyslog have been removed, or on a different debian system.  It might need some additional guards...

Anyway, wanted to shoot the PR in case you're interested in the changes.  Perhaps not this exact commit, but something similar at least.

Relevant Debian reference: https://wiki.debian.org/TimeZoneChanges#Restarting_Daemons_and_Long-Running_Programs
