### PR TITLE
Use not_if instead of ruby conditional to not update resource when unnecessary

### DIFF
--- a/recipes/linux-generic.rb
+++ b/recipes/linux-generic.rb
@@ -15,10 +15,9 @@ localtime_path = node.timezone.localtime_path
 
 ruby_block "confirm timezone" do
   block {
-    unless File.exist?(timezone_data_file)
-      raise "Can't find #{timezone_data_file}!"
-    end
+    raise "Can't find #{timezone_data_file}!"
   }
+  not_if { File.exist?(timezone_data_file) }
 end
 
 if node.timezone.use_symlink


### PR DESCRIPTION
Really small and simple change here!
I'm doing some cleanup and monitoring of the resources that are being updated in each chef run and this one pop out.
Using the chef guard _not_if_ instead of the ruby conditional _unless_ will have the same effect but will avoid the resource to be executed

Thanks for the cookbook!
