### PR TITLE
Update Node attribute references

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,7 @@ package value_for_platform_family(
   'default' => 'tzdata'
 )
 
-case node.platform_family
+case node['platform_family']
 when 'rhel'
   include_recipe value_for_platform(
     'amazon' => { 'default' => 'timezone-ii::amazon' },
@@ -23,29 +23,29 @@ when 'rhel'
   )
 
 when 'debian', 'fedora', 'pld'
-  include_recipe "timezone-ii::#{node.platform_family}"
+  include_recipe "timezone-ii::#{node['platform_family']}"
 
 else
-  if node.os == "linux"
+  if node['os'] == "linux"
     # Load the generic Linux recipe if there's no better known way to change the
     # timezone.  Log a warning (unless this is known to be the best way on a
     # particular platform).
-    message = "Linux platform '#{node.platform}' is unknown to this recipe; " +
+    message = "Linux platform '#{node['platform']}' is unknown to this recipe; " +
               "using generic Linux method"
     log message do
       level :warn
-      not_if { %w( centos gentoo rhel ).include? node.platform_family }
+      not_if { %w( centos gentoo rhel ).include? node['platform_family'] }
     end
 
     include_recipe 'timezone-ii::linux-generic'
 
   else
     message = "Don't know how to configure timezone for " +
-              "'#{node.platform_family}'!"
+              "'#{node['platform_family']}'!"
     log message do
       level :error
     end
 
-  end  # if/else node.os
+  end  # if/else node['os']
 
-end  # case node.platform_family
+end  # case node['platform_family']

--- a/recipes/linux-generic.rb
+++ b/recipes/linux-generic.rb
@@ -10,8 +10,8 @@
 # Generic timezone-changing method for Linux that should work for any distro
 # without a platform-specific method.
 
-timezone_data_file = File.join(node.timezone.tzdata_dir, node.tz)
-localtime_path = node.timezone.localtime_path
+timezone_data_file = File.join(node['timezone']['tzdata_dir'], node['tz'])
+localtime_path = node['timezone']['localtime_path']
 
 ruby_block "confirm timezone" do
   block {
@@ -21,7 +21,7 @@ ruby_block "confirm timezone" do
   }
 end
 
-if node.timezone.use_symlink
+if node['timezone']['use_symlink']
   link localtime_path do
     to timezone_data_file
     owner 'root'
@@ -41,4 +41,4 @@ else
                         " or set attribute ['timezone']['use_symlink']=true"
     }
   end
-end  # if/else node.timezone.use_symlink
+end  # if/else node['timezone']['use_symlink']

--- a/recipes/rhel7.rb
+++ b/recipes/rhel7.rb
@@ -8,4 +8,4 @@
 #
 
 # This sets the timezone on EL 7 distributions (e.g. RedHat and CentOS)
-execute "timedatectl --no-ask-password set-timezone #{node[:tz]}"
+execute "timedatectl --no-ask-password set-timezone #{node['tz']}"


### PR DESCRIPTION
Eliminate warnings:
WARN: method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"])
