### PR TITLE
tzdata not working for ubuntu >= 16.04.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Lawrence Leonard Gilbert"
 maintainer_email "larry@L2G.to"
 license          "Apache 2.0"
 description      "Configure the system timezone on *ix systems"
-version          "0.2.9992"
+version          "0.2.9993"
 
 replaces         "timezone"
 

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -13,6 +13,10 @@
 
 TIMEZONE_FILE = '/etc/timezone'
 
+file '/etc/localtime' do
+      action :delete
+end
+
 template TIMEZONE_FILE do
   source "timezone.conf.erb"
   owner 'root'


### PR DESCRIPTION
In ubuntu >= 16.04,  timezone is not getting set. After deletion of /etc/localtime, it worked.
